### PR TITLE
Fix naming

### DIFF
--- a/rules/amd059.lst
+++ b/rules/amd059.lst
@@ -144,7 +144,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/amd060.lst
+++ b/rules/amd060.lst
@@ -144,7 +144,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/amdfx059.lst
+++ b/rules/amdfx059.lst
@@ -144,7 +144,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/amdfx060.lst
+++ b/rules/amdfx060.lst
@@ -144,7 +144,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/broadwelle055.lst
+++ b/rules/broadwelle055.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.5.5
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Broadwell-E Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-hedt-config.plist/broadwell-e

--- a/rules/broadwelle056.lst
+++ b/rules/broadwelle056.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.5.6
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Broaswell-E Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-hedt-config.plist/broadwell-e

--- a/rules/broadwelle057.lst
+++ b/rules/broadwelle057.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.5.7
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Broadwell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/broadwell-e.html

--- a/rules/broadwelle058.lst
+++ b/rules/broadwelle058.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.5.8
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Broadwell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/broadwell-e.html

--- a/rules/broadwelle059.lst
+++ b/rules/broadwelle059.lst
@@ -131,7 +131,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/broadwelle059.lst
+++ b/rules/broadwelle059.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.5.9
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Broadwell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/broadwell-e.html

--- a/rules/broadwelle060.lst
+++ b/rules/broadwelle060.lst
@@ -1,4 +1,4 @@
-# Broadwell-E OpenCore 0.6.0
+# HEDT: (6th Gen) Broadwell-E OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Broadwell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/broadwell-e.html

--- a/rules/broadwelle060.lst
+++ b/rules/broadwelle060.lst
@@ -132,7 +132,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See Vault"
  Vault=Optional

--- a/rules/coffeelake055.lst
+++ b/rules/coffeelake055.lst
@@ -1,4 +1,4 @@
-# Coffee Lake OpenCore 0.5.5
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Coffee Lake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/coffee-lake

--- a/rules/coffeelake056.lst
+++ b/rules/coffeelake056.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Desktop OpenCore 0.5.6
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Coffee Lake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/coffee-lake

--- a/rules/coffeelake057.lst
+++ b/rules/coffeelake057.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Desktop OpenCore 0.5.7
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Coffee Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/coffee-lake.html

--- a/rules/coffeelake058.lst
+++ b/rules/coffeelake058.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Desktop OpenCore 0.5.8
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Coffee Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/coffee-lake.html

--- a/rules/coffeelake059.lst
+++ b/rules/coffeelake059.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Desktop OpenCore 0.5.9
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Coffee Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/coffee-lake.html

--- a/rules/coffeelake059.lst
+++ b/rules/coffeelake059.lst
@@ -133,7 +133,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/coffeelake060.lst
+++ b/rules/coffeelake060.lst
@@ -137,7 +137,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/coffeelake060.lst
+++ b/rules/coffeelake060.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Desktop OpenCore 0.6.0
+# Desktop: (8th, 9th Gen) Coffee Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Coffee Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/coffee-lake.html

--- a/rules/cometlake060.lst
+++ b/rules/cometlake060.lst
@@ -138,7 +138,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/cometlake060.lst
+++ b/rules/cometlake060.lst
@@ -1,6 +1,6 @@
-# Coffee Lake Desktop OpenCore 0.6.0
+# Desktop: (10th Gen) Comet Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
-=# OpenCore v0.6.0 Intel Coffee Lake Sanity Check
+=# OpenCore v0.6.0 Intel Comet Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/comet-lake.html
 =<hr>
 =[kernel]:https://dortania.github.io/OpenCore-Install-Guide/config.plist/comet-lake#kernel

--- a/rules/cometlake060.lst
+++ b/rules/cometlake060.lst
@@ -48,7 +48,7 @@ Booter
  ProtectCsmRegion~=.* "!**{$setting}** was deprecated in OpenCore v0.5.7 - See **ProtectMemoryRegions** instead"
  ProtectMemoryRegions=no
  ProtectSecureBoot=no
- ProtectUefiServices=no
+ ProtectUefiServices=yes
  ProvideCustomSlide=yes
  ProvideMaxSlide=0
  RebuildAppleMemoryMap=yes

--- a/rules/haswell055.lst
+++ b/rules/haswell055.lst
@@ -1,4 +1,4 @@
-# Haswell OpenCore 0.5.5
+# Desktop: (4th Gen) Haswell OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Haswell Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/haswell

--- a/rules/haswell056.lst
+++ b/rules/haswell056.lst
@@ -1,4 +1,4 @@
-# Haswell Desktop OpenCore 0.5.6
+# Desktop: (4th Gen) Haswell OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Haswell Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/haswell

--- a/rules/haswell057.lst
+++ b/rules/haswell057.lst
@@ -1,4 +1,4 @@
-# Haswell Desktop OpenCore 0.5.7
+# Desktop: (4th Gen) Haswell OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Haswell Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/haswell.html

--- a/rules/haswell058.lst
+++ b/rules/haswell058.lst
@@ -1,4 +1,4 @@
-# Haswell Desktop OpenCore 0.5.8
+# Desktop: (4th Gen) Haswell OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Haswell Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/haswell.html

--- a/rules/haswell059.lst
+++ b/rules/haswell059.lst
@@ -1,4 +1,4 @@
-# Haswell Desktop OpenCore 0.5.9
+# Desktop: (4th Gen) Haswell OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Haswell Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/haswell.html

--- a/rules/haswell059.lst
+++ b/rules/haswell059.lst
@@ -132,7 +132,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/haswell060.lst
+++ b/rules/haswell060.lst
@@ -1,4 +1,4 @@
-# Haswell Desktop OpenCore 0.6.0
+# Desktop: (4th Gen) Haswell OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Haswell Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/haswell.html

--- a/rules/haswell060.lst
+++ b/rules/haswell060.lst
@@ -136,7 +136,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/haswelle055.lst
+++ b/rules/haswelle055.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.5.5
+# HEDT: (5th Gen) Haswell-E OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Haswell-E Sanity Check
 =https://github.com/khronokernel/OpenCore-Vanilla-Desktop-Guide/blob/master/config-HEDT/haswell-e.md

--- a/rules/haswelle056.lst
+++ b/rules/haswelle056.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.5.6
+# HEDT: (5th Gen) Haswell-E OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Haswell-E Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-hedt-config.plist/haswell-e

--- a/rules/haswelle057.lst
+++ b/rules/haswelle057.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.5.7
+# HEDT: (5th Gen) Haswell-E OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Haswell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/haswell-e.html

--- a/rules/haswelle058.lst
+++ b/rules/haswelle058.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.5.8
+# HEDT: (5th Gen) Haswell-E OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Haswell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/haswell-e.html

--- a/rules/haswelle059.lst
+++ b/rules/haswelle059.lst
@@ -128,7 +128,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/haswelle059.lst
+++ b/rules/haswelle059.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.5.9
+# HEDT: (5th Gen) Haswell-E OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Haswell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/haswell-e.html

--- a/rules/haswelle060.lst
+++ b/rules/haswelle060.lst
@@ -1,4 +1,4 @@
-# Haswell-E OpenCore 0.6.0
+# HEDT: (5th Gen) Haswell-E OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Haswell-E Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/haswell-e.html

--- a/rules/haswelle060.lst
+++ b/rules/haswelle060.lst
@@ -129,7 +129,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/ivybridge055.lst
+++ b/rules/ivybridge055.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge OpenCore 0.5.5
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Ivy Bridge Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/ivy-bridge

--- a/rules/ivybridge056.lst
+++ b/rules/ivybridge056.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Desktop OpenCore 0.5.6
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Ivy Bridge Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/ivy-bridge

--- a/rules/ivybridge057.lst
+++ b/rules/ivybridge057.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Desktop OpenCore 0.5.7
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Ivy Bridge Desktop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/ivy-bridge.html

--- a/rules/ivybridge058.lst
+++ b/rules/ivybridge058.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Desktop OpenCore 0.5.8
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Ivy Bridge Desktop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/ivy-bridge.html

--- a/rules/ivybridge059.lst
+++ b/rules/ivybridge059.lst
@@ -138,7 +138,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/ivybridge059.lst
+++ b/rules/ivybridge059.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Desktop OpenCore 0.5.9
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Ivy Bridge Desktop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/ivy-bridge.html

--- a/rules/ivybridge060.lst
+++ b/rules/ivybridge060.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Desktop OpenCore 0.6.0
+# Desktop: (3rd Gen) Ivy Bridge OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Ivy Bridge Desktop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/ivy-bridge.html

--- a/rules/ivybridge060.lst
+++ b/rules/ivybridge060.lst
@@ -141,7 +141,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/kabylake055.lst
+++ b/rules/kabylake055.lst
@@ -1,4 +1,4 @@
-# Kaby Lake OpenCore 0.5.5
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel Kaby Lake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/kaby-lake

--- a/rules/kabylake056.lst
+++ b/rules/kabylake056.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Desktop OpenCore 0.5.6
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel Kaby Lake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/kaby-lake

--- a/rules/kabylake057.lst
+++ b/rules/kabylake057.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Desktop OpenCore 0.5.7
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel Kaby Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/kaby-lake.html

--- a/rules/kabylake058.lst
+++ b/rules/kabylake058.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Desktop OpenCore 0.5.8
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel Kaby Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/kaby-lake.html

--- a/rules/kabylake059.lst
+++ b/rules/kabylake059.lst
@@ -131,7 +131,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/kabylake059.lst
+++ b/rules/kabylake059.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Desktop OpenCore 0.5.9
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel Kaby Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/kaby-lake.html

--- a/rules/kabylake060.lst
+++ b/rules/kabylake060.lst
@@ -135,7 +135,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/kabylake060.lst
+++ b/rules/kabylake060.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Desktop OpenCore 0.6.0
+# Desktop: (7th Gen) Kaby Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Kaby Lake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/kaby-lake.html

--- a/rules/laptopbroadwell060.lst
+++ b/rules/laptopbroadwell060.lst
@@ -138,7 +138,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopbroadwell060.lst
+++ b/rules/laptopbroadwell060.lst
@@ -1,4 +1,4 @@
-# Broadwell Laptop OpenCore 0.6.0
+# Laptop: (5th Gen) Broadwell OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Broadwell Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/broadwell.html

--- a/rules/laptopcoffeelake060.lst
+++ b/rules/laptopcoffeelake060.lst
@@ -1,4 +1,4 @@
-# Coffee Lake Laptop OpenCore 0.6.0
+# Laptop: (8th Gen) Coffee Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Coffee Lake Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/coffee-lake.html

--- a/rules/laptopcoffeelake060.lst
+++ b/rules/laptopcoffeelake060.lst
@@ -141,7 +141,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopcoffeelakeplus060.lst
+++ b/rules/laptopcoffeelakeplus060.lst
@@ -1,6 +1,6 @@
-# Coffee Lake Plus Laptop OpenCore 0.6.0
+# Laptop: (9th, 10th Gen) Coffee and Comet Lake Plus OpenCore 0.6.0
 # Generic config suitable for initial installation
-=# OpenCore v0.6.0 Intel Coffee Lake Plus Laptop Sanity Check
+=# OpenCore v0.6.0 Intel Coffee and Comet Lake Plus Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/coffee-lake-plus.html
 =<hr>
 =[kernel]:https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/coffee-lake-plus#kernel

--- a/rules/laptopcoffeelakeplus060.lst
+++ b/rules/laptopcoffeelakeplus060.lst
@@ -141,7 +141,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptophaswell060.lst
+++ b/rules/laptophaswell060.lst
@@ -138,7 +138,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptophaswell060.lst
+++ b/rules/laptophaswell060.lst
@@ -1,4 +1,4 @@
-# Haswell Laptop OpenCore 0.6.0
+# Laptop: (4th Gen) Haswell OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Haswell Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/haswell.html

--- a/rules/laptopicelake060.lst
+++ b/rules/laptopicelake060.lst
@@ -1,4 +1,4 @@
-# Ice Lake Laptop OpenCore 0.6.0
+# Laptop: (10th Gen) Ice Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Ice Lake Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/icelake.html

--- a/rules/laptopicelake060.lst
+++ b/rules/laptopicelake060.lst
@@ -51,7 +51,7 @@ Booter
  ProtectCsmRegion~=.* "!**{$setting}** was deprecated in OpenCore v0.5.7 - See **ProtectMemoryRegions** instead"
  ProtectMemoryRegions=no
  ProtectSecureBoot=no
- ProtectUefiServices=no
+ ProtectUefiServices=yes
  ProvideCustomSlide=yes
  ProvideMaxSlide=0
  RebuildAppleMemoryMap=yes

--- a/rules/laptopicelake060.lst
+++ b/rules/laptopicelake060.lst
@@ -141,7 +141,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopivybridge060.lst
+++ b/rules/laptopivybridge060.lst
@@ -1,4 +1,4 @@
-# Ivy Bridge Laptop OpenCore 0.6.0
+# Laptop: (3rd Gen) Ivy Bridge OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Ivy Bridge Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/ivy-bridge.html

--- a/rules/laptopivybridge060.lst
+++ b/rules/laptopivybridge060.lst
@@ -143,7 +143,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopkabylake060.lst
+++ b/rules/laptopkabylake060.lst
@@ -139,7 +139,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopkabylake060.lst
+++ b/rules/laptopkabylake060.lst
@@ -1,4 +1,4 @@
-# Kaby Lake Laptop OpenCore 0.6.0
+# Laptop: (7th Gen) Kaby Lake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel Kaby Lake Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/kaby-lake.html

--- a/rules/laptopskylake060.lst
+++ b/rules/laptopskylake060.lst
@@ -139,7 +139,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/laptopskylake060.lst
+++ b/rules/laptopskylake060.lst
@@ -1,4 +1,4 @@
-# SkyLake Laptop OpenCore 0.6.0
+# Laptop: (6th Gen) SkyLake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel SkyLake Laptop Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-laptop.plist/skylake.html

--- a/rules/skylake055.lst
+++ b/rules/skylake055.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.5.5
+# Desktop: (6th Gen) SkyLake OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel SkyLake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/skylake

--- a/rules/skylake056.lst
+++ b/rules/skylake056.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.5.6
+# Desktop: (6th Gen) SkyLake OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel SkyLake Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-config.plist/skylake

--- a/rules/skylake057.lst
+++ b/rules/skylake057.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.5.7
+# Desktop: (6th Gen) SkyLake OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel SkyLake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/skylake.html

--- a/rules/skylake058.lst
+++ b/rules/skylake058.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.5.8
+# Desktop: (6th Gen) SkyLake OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel SkyLake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/skylake.html

--- a/rules/skylake059.lst
+++ b/rules/skylake059.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.5.9
+# Desktop: (6th Gen) SkyLake OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel SkyLake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/skylake.html

--- a/rules/skylake059.lst
+++ b/rules/skylake059.lst
@@ -131,7 +131,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/skylake060.lst
+++ b/rules/skylake060.lst
@@ -135,7 +135,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/skylake060.lst
+++ b/rules/skylake060.lst
@@ -1,4 +1,4 @@
-# SkyLake Desktop OpenCore 0.6.0
+# Desktop: (6th Gen) SkyLake OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel SkyLake Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config.plist/skylake.html

--- a/rules/skylakex055.lst
+++ b/rules/skylakex055.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.5.5
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.5.5
 # Generic config suitable for initial installation
 =# OpenCore v0.5.5 Intel SkyLake-X Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-hedt-config.plist/skylake-x

--- a/rules/skylakex056.lst
+++ b/rules/skylakex056.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.5.6
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.5.6
 # Generic config suitable for initial installation
 =# OpenCore v0.5.6 Intel SkyLake-X Sanity Check
 =https://khronokernel-2.gitbook.io/opencore-vanilla-desktop-guide/intel-hedt-config.plist/skylake-x

--- a/rules/skylakex057.lst
+++ b/rules/skylakex057.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.5.7
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.5.7
 # Generic config suitable for initial installation
 =# OpenCore v0.5.7 Intel SkyLake-X Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/skylake-x.html

--- a/rules/skylakex058.lst
+++ b/rules/skylakex058.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.5.8
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.5.8
 # Generic config suitable for initial installation
 =# OpenCore v0.5.8 Intel SkyLake-X Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/skylake-x.html

--- a/rules/skylakex059.lst
+++ b/rules/skylakex059.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.5.9
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.5.9
 # Generic config suitable for initial installation
 =# OpenCore v0.5.9 Intel SkyLake-X Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/skylake-x.html

--- a/rules/skylakex059.lst
+++ b/rules/skylakex059.lst
@@ -127,7 +127,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate=yes
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional

--- a/rules/skylakex060.lst
+++ b/rules/skylakex060.lst
@@ -1,4 +1,4 @@
-# SkyLake-X OpenCore 0.6.0
+# HEDT: (7th, 9th, 10th Gen) SkyLake-X OpenCore 0.6.0
 # Generic config suitable for initial installation
 =# OpenCore v0.6.0 Intel SkyLake-X Sanity Check
 =https://dortania.github.io/OpenCore-Install-Guide/config-HEDT/skylake-x.html

--- a/rules/skylakex060.lst
+++ b/rules/skylakex060.lst
@@ -128,7 +128,7 @@ Misc
  AllowSetDefault=yes
  AuthRestart=no
  BlacklistAppleUpdate~=.* "!**{$setting}** was deprecated in OpenCore v0.6.0 - See **run-efi-updater** under NVRAM instead"
- BootProtect=Bootstrap
+ BootProtect~=.* " **{$setting}** = **{$value}**"
  RequireSignature~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  RequireVault~=.* "!**{$setting}** was deprecated in OpenCore v0.5.6 - See **Vault**"
  Vault=Optional


### PR DESCRIPTION
So just realized I had a typo in the Comet Lake page, but thought this is a good time to clean up the config table so it's in proper order(instead of CPU name, it's ordered by hardware type, then generation, then arch name)